### PR TITLE
let rake create required directories and enable rake without arguments

### DIFF
--- a/hamming/rakefile.rb
+++ b/hamming/rakefile.rb
@@ -1,6 +1,9 @@
+Dir.mkdir("build") unless Dir.exist?("build")
+Dir.mkdir("src") unless Dir.exist?("src")
+
 PROJECT_CEEDLING_ROOT = "../vendor/ceedling"
 load "#{PROJECT_CEEDLING_ROOT}/lib/ceedling.rb"
 
 Ceedling.load_project
 
-task :default => %w[ test:all release ]
+task :default => %w[ test:all ]

--- a/raindrops/rakefile.rb
+++ b/raindrops/rakefile.rb
@@ -1,6 +1,9 @@
+Dir.mkdir("build") unless Dir.exist?("build")
+Dir.mkdir("src") unless Dir.exist?("src")
+
 PROJECT_CEEDLING_ROOT = "../vendor/ceedling"
 load "#{PROJECT_CEEDLING_ROOT}/lib/ceedling.rb"
 
 Ceedling.load_project
 
-task :default => %w[ test:all release ]
+task :default => %w[ test:all ]


### PR DESCRIPTION
Currently it is rather complicated to prepare the C track (see https://gist.github.com/7083c629a709b01f63fc). This patch prevents rather cryptic error messages like 

```
ERROR: Config filepath [:project][:build_root]['build'] does not exist on disk.
rake aborted!

/vagrant/exercism/c/vendor/ceedling/lib/ceedling/configurator.rb:265:in `validate'
/vagrant/exercism/c/vendor/ceedling/lib/ceedling/setupinator.rb:30:in `do_setup'
/vagrant/exercism/c/vendor/ceedling/lib/ceedling/rakefile.rb:46:in `<top (required)>'
/vagrant/exercism/c/vendor/ceedling/lib/ceedling.rb:66:in `load'
/vagrant/exercism/c/vendor/ceedling/lib/ceedling.rb:66:in `load_project'
/vagrant/exercism/c/raindrops/rakefile.rb:7:in `<top (required)>'
(See full trace by running task with --trace)
```

and it enables the user to type ``rake`` instead of ``rake test:all``.