### PR TITLE
Add tests for buffer overflows

### DIFF
--- a/exercises/hello-world/test/test_hello_world.c
+++ b/exercises/hello-world/test/test_hello_world.c
@@ -20,6 +20,12 @@ void test_hello_bob(){
   TEST_ASSERT_EQUAL_STRING("Hello, Bob!", buffer);
 }
 
+void test_no_buffer_overflow_for_small_buffer(){
+  buffer[8] = '?';
+  hello(buffer, 8, "Mr. President");
+  TEST_ASSERT_EQUAL('?', buffer[8]);
+}
+
 int main(void)
 {
   
@@ -28,6 +34,7 @@ int main(void)
   RUN_TEST(test_hello_no_name);
   RUN_TEST(test_hello_alice);
   RUN_TEST(test_hello_bob);
+  RUN_TEST(test_no_buffer_overflow_for_small_buffer);
 
   UnityEnd();
   return 0;

--- a/exercises/raindrops/test/test_raindrops.c
+++ b/exercises/raindrops/test/test_raindrops.c
@@ -104,6 +104,22 @@ void test_big_prime_yields_itself(void)
     TEST_ASSERT_EQUAL_STRING("12121", convert(buffer, sizeof(buffer), 12121));
 }
 
+void test_no_buffer_overflow_for_plingplangplong(void)
+{
+    char buffer[BUFFER_LENGTH];
+    buffer[8] = '?';
+    convert(buffer, 8, 105);
+    TEST_ASSERT_EQUAL('?', buffer[8]);
+}
+
+void test_no_buffer_overflow_for_number(void)
+{
+    char buffer[BUFFER_LENGTH];
+    buffer[5] = '?';
+    convert(buffer, 5, 10007);
+    TEST_ASSERT_EQUAL('?', buffer[5]);
+}
+
 int main(void)
 {
   UnityBegin("raindrops.c");
@@ -140,6 +156,8 @@ int main(void)
   RUN_TEST(test_fifty_two_yields_itself);
   RUN_TEST(test_one_hundred_five_yields_plingplangplong);
   RUN_TEST(test_big_prime_yields_itself);
+  RUN_TEST(test_no_buffer_overflow_for_plingplangplong);
+  RUN_TEST(test_no_buffer_overflow_for_number);
 
   UnityEnd();
   return 0;


### PR DESCRIPTION
In exercises where the solution is written to a buffer, there should be a test for buffer overflows. Buffer overflows are a a common error source in C so we should help our users to avoid them.