### PR TITLE
Explicitely state when functions don't take args.

### DIFF
--- a/exercises/anagram/test/test_anagram.c
+++ b/exercises/anagram/test/test_anagram.c
@@ -4,7 +4,7 @@
 #include "vendor/unity.h"
 #include "../src/anagram.h"
 
-void testReset()
+void testReset(void)
 {
 }
 

--- a/exercises/hello-world/test/test_hello_world.c
+++ b/exercises/hello-world/test/test_hello_world.c
@@ -5,22 +5,22 @@
 
 char buffer[BUFFER_LENGTH];
 
-void test_hello_no_name() {
+void test_hello_no_name(void) {
   hello(buffer, BUFFER_LENGTH, "");
   TEST_ASSERT_EQUAL_STRING("Hello, World!", buffer);
 }
 
-void test_hello_alice() {
+void test_hello_alice(void) {
   hello(buffer, BUFFER_LENGTH, "Alice");
   TEST_ASSERT_EQUAL_STRING("Hello, Alice!", buffer);
 }
 
-void test_hello_bob(){
+void test_hello_bob(void){
   hello(buffer, BUFFER_LENGTH, "Bob");
   TEST_ASSERT_EQUAL_STRING("Hello, Bob!", buffer);
 }
 
-void test_no_buffer_overflow_for_small_buffer(){
+void test_no_buffer_overflow_for_small_buffer(void){
   buffer[8] = '?';
   hello(buffer, 8, "Mr. President");
   TEST_ASSERT_EQUAL('?', buffer[8]);


### PR DESCRIPTION
With -Werror=strict-prototypes functions without arguments must be
declared as "return_type function_name(void)". -Werror=strict-prototypes
is in the CFLAGS variable of the make files, though unused.