### PR TITLE
Remove references to deprecated help.exercism.io

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,11 +1,9 @@
 ## Getting Started
 
-Make sure you have read the [getting started with C][getting-started]
-page on the [exercism help site](http://help.exercism.io/). This covers
+Make sure you have read the
+[C page](http://exercism.io/languages/c) on the exercism site. This covers
 the basic information on setting up the development environment expected
 by the exercises.
-
-[getting-started]: http://help.exercism.io/getting-started-with-c.html
 
 
 ## Passing the Tests


### PR DESCRIPTION
Closes #27.