### PR TITLE
Recompile tests on any change to tests or code.

### DIFF
--- a/exercises/anagram/makefile
+++ b/exercises/anagram/makefile
@@ -21,6 +21,6 @@ test: tests.out
 clean:
 	rm -f *.o *.out
 
-tests.out:
+tests.out: test/test_anagram.c src/anagram.c
 	@echo Compiling $@
 	@cc src/anagram.c test/vendor/unity.c test/test_anagram.c -o tests.out

--- a/exercises/bob/makefile
+++ b/exercises/bob/makefile
@@ -21,6 +21,6 @@ test: tests.out
 clean:
 	rm -f *.o *.out
 
-tests.out:
+tests.out: test/test_bob.c src/bob.c
 	@echo Compiling $@
 	@cc src/bob.c test/vendor/unity.c test/test_bob.c -o tests.out

--- a/exercises/hamming/makefile
+++ b/exercises/hamming/makefile
@@ -21,6 +21,6 @@ test: tests.out
 clean:
 	rm -f *.o *.out
 
-tests.out:
+tests.out: test/test_hamming.c src/hamming.c
 	@echo Compiling $@
 	@cc src/hamming.c test/vendor/unity.c test/test_hamming.c -o tests.out

--- a/exercises/hello-world/makefile
+++ b/exercises/hello-world/makefile
@@ -21,6 +21,6 @@ test: tests.out
 clean:
 	rm -f *.o *.out
 
-tests.out:
+tests.out: test/test_hello_world.c src/hello_world.c
 	@echo Compiling $@
 	@cc src/hello_world.c test/vendor/unity.c test/test_hello_world.c -o tests.out

--- a/exercises/leap/makefile
+++ b/exercises/leap/makefile
@@ -21,6 +21,6 @@ test: tests.out
 clean:
 	rm -f *.o *.out
 
-tests.out:
+tests.out: test/test_leap.c src/leap.c
 	@echo Compiling $@
 	@cc src/leap.c test/vendor/unity.c test/test_leap.c -o tests.out

--- a/exercises/raindrops/makefile
+++ b/exercises/raindrops/makefile
@@ -21,6 +21,6 @@ test: tests.out
 clean:
 	rm -f *.o *.out
 
-tests.out:
+tests.out: test/test_raindrops.c src/raindrops.c
 	@echo Compiling $@
 	@cc src/raindrops.c test/vendor/unity.c test/test_raindrops.c -o tests.out


### PR DESCRIPTION
While practicing Hello World and Anagram, as I figured out what I was doing, I wanted to comment or uncomment tests. I expected that doing so would exclude or include those tests at runtime, but it didn't. Same problem as I was editing my solution. This commit tells `make` (for all exercises) that the compiled tests have dependencies on files in `src` and `test`, so that the tests get rebuilt when I expect.