### PR TITLE
Remove explicitly passed string length in Hamming

### DIFF
--- a/exercises/hamming/src/example.c
+++ b/exercises/hamming/src/example.c
@@ -2,12 +2,12 @@
 #include <string.h>
 #include "hamming.h"
 
-int compute(const char *lhs, const char *rhs)
+size_t compute(const char *lhs, const char *rhs)
 {
    size_t lhs_len = strlen(lhs);
    size_t rhs_len = strlen(rhs);
-   int count = 0;
-   int i = 0;
+   size_t count = 0;
+   size_t i = 0;
    for (i = 0; i < lhs_len && i < rhs_len; ++i) {
       if (lhs[i] != rhs[i]) {
          ++count;

--- a/exercises/hamming/src/example.c
+++ b/exercises/hamming/src/example.c
@@ -1,13 +1,16 @@
+#include <stddef.h>
+#include <string.h>
 #include "hamming.h"
 
-int compute(char *lhs, int lhs_len, char *rhs, int rhs_len) {
+int compute(const char *lhs, const char *rhs) {
+    size_t lhs_len = strlen(lhs);
+    size_t rhs_len = strlen(rhs);
     int count = 0;
     int i = 0;
-    for (i=0; i<lhs_len && i<rhs_len; ++i) {
+    for (i = 0; i < lhs_len && i < rhs_len; ++i) {
         if(lhs[i] != rhs[i]) {
             ++count;
         }
     }
     return count;
 }
-

--- a/exercises/hamming/src/example.h
+++ b/exercises/hamming/src/example.h
@@ -1,6 +1,6 @@
 #ifndef _HAMMING_H
 #define _HAMMING_H
 
-int compute(const char *lhs, const char *rhs);
+size_t compute(const char *lhs, const char *rhs);
 
 #endif

--- a/exercises/hamming/src/example.h
+++ b/exercises/hamming/src/example.h
@@ -1,6 +1,6 @@
 #ifndef _HAMMING_H
 #define _HAMMING_H
 
-int compute(char *lhs, int lhs_len, char * rhs, int rhs_len);
+int compute(const char *lhs, const char * rhs);
 
-#endif // _HAMMING_H
+#endif

--- a/exercises/hamming/test/test_hamming.c
+++ b/exercises/hamming/test/test_hamming.c
@@ -1,65 +1,52 @@
 #include "vendor/unity.h"
 #include "../src/hamming.h"
 
-void setUp(void)
-{
+void setUp(void) {
 }
 
-void tearDown(void)
-{
+void tearDown(void) {
 }
 
-void resetTest(void)
-{
+void resetTest(void) {
   tearDown();
   setUp();
 }
 
-void test_no_difference_between_identical_strands(void)
-{
-    TEST_ASSERT_EQUAL(0, compute("A", 1, "A", 1));
+void test_no_difference_between_identical_strands(void) {
+    TEST_ASSERT_EQUAL(0, compute("A", "A"));
 }
 
-void test_hamming_distance_for_single_nucleotide_strand(void)
-{
-    TEST_ASSERT_EQUAL(1, compute("A", 1, "G", 1));
+void test_hamming_distance_for_single_nucleotide_strand(void) {
+    TEST_ASSERT_EQUAL(1, compute("A", "G"));
 }
 
-void test_complete_hamming_distance_for_small_strand(void)
-{
-    TEST_ASSERT_EQUAL(2, compute("AG", 2, "CT", 2));
+void test_complete_hamming_distance_for_small_strand(void) {
+    TEST_ASSERT_EQUAL(2, compute("AG", "CT"));
 }
 
-void test_small_hamming_distance(void)
-{
-    TEST_ASSERT_EQUAL(1, compute("AT", 2, "CT", 2));
+void test_small_hamming_distance(void) {
+    TEST_ASSERT_EQUAL(1, compute("AT", "CT"));
 }
 
-void test_small_hamming_distance_in_longer_strand(void)
-{
-    TEST_ASSERT_EQUAL(1, compute("GGACG", 4, "GGTCG", 5));
+void test_small_hamming_distance_in_longer_strand(void) {
+    TEST_ASSERT_EQUAL(1, compute("GGACG", "GGTCG"));
 }
 
-void test_ignores_extra_length_on_first_strand_when_longer(void)
-{
-    TEST_ASSERT_EQUAL(0, compute("AAAG", 4, "AAA", 3));
+void test_ignores_extra_length_on_first_strand_when_longer(void) {
+    TEST_ASSERT_EQUAL(0, compute("AAAG", "AAA"));
 }
 
-void test_ignores_extra_length_on_other_strand_when_longer(void)
-{
-    TEST_ASSERT_EQUAL(0, compute("AAA", 3, "AAAG", 4));
+void test_ignores_extra_length_on_other_strand_when_longer(void) {
+    TEST_ASSERT_EQUAL(0, compute("AAA", "AAAG"));
 }
 
-void test_large_hamming_distance(void)
-{
-    TEST_ASSERT_EQUAL(4, compute("GATACA", 6, "GCATAA", 6));
+void test_large_hamming_distance(void) {
+    TEST_ASSERT_EQUAL(4, compute("GATACA", "GCATAA"));
 }
 
-void test_hamming_distance_in_very_long_strand(void)
-{
-    TEST_ASSERT_EQUAL(9, compute("GGACGGATTCTG", 12, "AGGACGGATTCT", 12));
+void test_hamming_distance_in_very_long_strand(void) {
+    TEST_ASSERT_EQUAL(9, compute("GGACGGATTCTG", "AGGACGGATTCT"));
 }
-
 
 int main(void)
 {
@@ -76,5 +63,6 @@ int main(void)
   RUN_TEST(test_hamming_distance_in_very_long_strand);
 
   UnityEnd();
+
   return 0;
 }

--- a/exercises/rna-transcription/src/example.c
+++ b/exercises/rna-transcription/src/example.c
@@ -2,29 +2,30 @@
 #include <string.h>
 #include "rna_transcription.h"
 
-char *to_rna(const char *dna) {
-  size_t len = strlen(dna);
-  char *rna = malloc(sizeof(char) * len);
+char *to_rna(const char *dna)
+{
+   size_t len = strlen(dna);
+   char *rna = malloc(sizeof(char) * len);
 
-  for (size_t i = 0; i < len; i++) {
-    switch (dna[i]) {
-    case 'G':
-      rna[i] = 'C';
-      break;
-    case 'C':
-      rna[i] = 'G';
-      break;
-    case 'T':
-      rna[i] = 'A';
-      break;
-    case 'A':
-      rna[i] = 'U';
-      break;
-    default:
-      free(rna);
-      return NULL;
-    }
-  }
+   for (size_t i = 0; i < len; i++) {
+      switch (dna[i]) {
+      case 'G':
+         rna[i] = 'C';
+         break;
+      case 'C':
+         rna[i] = 'G';
+         break;
+      case 'T':
+         rna[i] = 'A';
+         break;
+      case 'A':
+         rna[i] = 'U';
+         break;
+      default:
+         free(rna);
+         return NULL;
+      }
+   }
 
-  return rna;
+   return rna;
 }

--- a/exercises/rna-transcription/test/test_rna_transcription.c
+++ b/exercises/rna-transcription/test/test_rna_transcription.c
@@ -3,60 +3,71 @@
 #include <stdlib.h>
 #include <string.h>
 
-void test_transcription(const char *dna, const char *expected) {
-  char *rna = to_rna(dna);
-  TEST_ASSERT_TRUE(strncmp(rna, expected, strlen(dna)) == 0);
-  free(rna);
+void test_transcription(const char *dna, const char *expected)
+{
+   char *rna = to_rna(dna);
+   TEST_ASSERT_TRUE(strncmp(rna, expected, strlen(dna)) == 0);
+   free(rna);
 }
 
-void test_failure(const char *dna) {
-  TEST_ASSERT_TRUE(to_rna(dna) == NULL);
+void test_failure(const char *dna)
+{
+   TEST_ASSERT_TRUE(to_rna(dna) == NULL);
 }
 
-void test_transcribes_G_to_C(void) {
-  test_transcription("G", "C");
+void test_transcribes_G_to_C(void)
+{
+   test_transcription("G", "C");
 }
 
-void test_transcribes_C_to_G(void) {
-  test_transcription("C", "G");
+void test_transcribes_C_to_G(void)
+{
+   test_transcription("C", "G");
 }
 
-void test_transcribes_T_to_A(void) {
-  test_transcription("T", "A");
+void test_transcribes_T_to_A(void)
+{
+   test_transcription("T", "A");
 }
 
-void test_transcribes_A_to_U(void) {
-  test_transcription("A", "U");
+void test_transcribes_A_to_U(void)
+{
+   test_transcription("A", "U");
 }
 
-void test_transcribes_all_occurrences(void) {
-  test_transcription("ACGTGGTCTTAA", "UGCACCAGAAUU");
+void test_transcribes_all_occurrences(void)
+{
+   test_transcription("ACGTGGTCTTAA", "UGCACCAGAAUU");
 }
 
-void test_handle_invalid_nucleotide(void) {
-  test_failure("U");
+void test_handle_invalid_nucleotide(void)
+{
+   test_failure("U");
 }
 
-void test_handle_completely_invalid_input(void) {
-  test_failure("XXX");
+void test_handle_completely_invalid_input(void)
+{
+   test_failure("XXX");
 }
 
-void test_handle_partially_invalid_input(void) {
-  test_failure("ACGTXXXCTTAA");
+void test_handle_partially_invalid_input(void)
+{
+   test_failure("ACGTXXXCTTAA");
 }
 
-int main(void) {
-  UnityBegin("test/test_rna_transcription.c");
+int main(void)
+{
+   UnityBegin("test/test_rna_transcription.c");
 
-  RUN_TEST(test_transcribes_G_to_C);
-  RUN_TEST(test_transcribes_C_to_G);
-  RUN_TEST(test_transcribes_T_to_A);
-  RUN_TEST(test_transcribes_A_to_U);
-  RUN_TEST(test_transcribes_all_occurrences);
-  RUN_TEST(test_handle_invalid_nucleotide);
-  RUN_TEST(test_handle_completely_invalid_input);
-  RUN_TEST(test_handle_partially_invalid_input);
+   RUN_TEST(test_transcribes_G_to_C);
+   RUN_TEST(test_transcribes_C_to_G);
+   RUN_TEST(test_transcribes_T_to_A);
+   RUN_TEST(test_transcribes_A_to_U);
+   RUN_TEST(test_transcribes_all_occurrences);
+   RUN_TEST(test_handle_invalid_nucleotide);
+   RUN_TEST(test_handle_completely_invalid_input);
+   RUN_TEST(test_handle_partially_invalid_input);
 
-  UnityEnd();
-  return 0;
+   UnityEnd();
+   return 0;
 }


### PR DESCRIPTION
I cleaned up the `compute` interface by removing explicitly passed (and error-prone) string length and calculated with `strlen` instead.

Closes #41 