### PR TITLE
Fixed include guard for Anagram.h

### DIFF
--- a/exercises/anagram/src/anagram.h
+++ b/exercises/anagram/src/anagram.h
@@ -1,5 +1,5 @@
-#ifndef _EXAMPLE_H
-#define _EXAMPLE_H
+#ifndef _ANAGRAM_H
+#define _ANAGRAM_H
 
 #define MAX_STR_LEN 20
 


### PR DESCRIPTION
Looks like a gremlin got left in when we changed this from `example.h` to `anagram.h`.