### PR TITLE
Configure Travis task to execute tests for all examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ script:
 - bin/fetch-configlet
 - bin/configlet .
 - bin/verify-indent
+- bin/run-tests

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# xC
+# xC [![Build Status](https://travis-ci.org/exercism/xc.svg?branch=master)](https://travis-ci.org/exercism/xc)
 
 Exercism problems in C
 

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -10,21 +10,19 @@ for D in ../exercises/*; do
         # Copy the examples with the correct name for the exercise
         if [ -e "${D}/src/example.c" ]
         then
-          echo Generating "${D}/src/${EXERCISE_NAME}.c"
           cp -n ${D}/src/example.c ${D}/src/${EXERCISE_NAME}.c
         fi
 
         if [ -e "${D}/src/example.h" ]
         then
-          echo Generating "${D}/src/${EXERCISE_NAME}.h"
           cp -n ${D}/src/example.h ${D}/src/${EXERCISE_NAME}.h
         fi
 
         # Make it!
-        ( cd ${D} ; make clean; make )
-
-        # Clean up
-        #rm -f ${D}/src/${EXERCISE_NAME}.c
-        #rm -f ${D}/src/${EXERCISE_NAME}.h
+        ( cd ${D};
+          echo "Running tests for ${EXERCISE_NAME}";
+          make clean >> /dev/null; # I'm just trying to suppress the output (I'm sure there's a much better way)
+          make | grep FAIL:  # Only output failures
+        )
     fi
 done

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -8,14 +8,23 @@ for D in ../exercises/*; do
         EXERCISE_NAME="${STRIPPED_OF_EXTENSION:5}"
 
         # Copy the examples with the correct name for the exercise
-        cp -f ${D}/src/example.c ${D}/src/${EXERCISE_NAME}.c
-        cp -f ${D}/src/example.h ${D}/src/${EXERCISE_NAME}.h
+        if [ -e "${D}/src/example.c" ]
+        then
+          echo Generating "${D}/src/${EXERCISE_NAME}.c"
+          cp -n ${D}/src/example.c ${D}/src/${EXERCISE_NAME}.c
+        fi
+
+        if [ -e "${D}/src/example.h" ]
+        then
+          echo Generating "${D}/src/${EXERCISE_NAME}.h"
+          cp -n ${D}/src/example.h ${D}/src/${EXERCISE_NAME}.h
+        fi
 
         # Make it!
         ( cd ${D} ; make clean; make )
 
         # Clean up
-        rm -f ${D}/src/${EXERCISE_NAME}.c
-        rm -f ${D}/src/${EXERCISE_NAME}.h
+        #rm -f ${D}/src/${EXERCISE_NAME}.c
+        #rm -f ${D}/src/${EXERCISE_NAME}.h
     fi
 done

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -26,6 +26,7 @@ for D in exercises/*; do
           make clean >> /dev/null; # I'm just trying to suppress the output (I'm sure there's a much better way)
           if make | grep FAIL: ; then
             set -e
+            exit 1
           fi
           cd ${CURRENT_DIR};
         }

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Remove -Wpedantic from all makefiles since it isn't supported in the GCC version used by Travis
-sed -i -- 's/-Wpedantic/-pedantic/g' exercises/*/makefile
-
 for D in exercises/*; do
     CURRENT_DIR=$(pwd)
 

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -12,12 +12,12 @@ for D in exercises/*; do
         # Copy the examples with the correct name for the exercise
         if [ -e "${D}/src/example.c" ]
         then
-          cp -n ${D}/src/example.c ${D}/src/${EXERCISE_NAME}.c
+          cp ${D}/src/example.c ${D}/src/${EXERCISE_NAME}.c
         fi
 
         if [ -e "${D}/src/example.h" ]
         then
-          cp -n ${D}/src/example.h ${D}/src/${EXERCISE_NAME}.h
+          cp ${D}/src/example.h ${D}/src/${EXERCISE_NAME}.h
         fi
 
         # Make it!

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 for D in ../exercises/*; do
+    CURRENT_DIR=$(pwd)
+
     if [ -d "${D}" ]; then
         # Get the exercise name from the test file
         TEST_FILE=$(basename $(ls ${D}/test/test*))
@@ -19,10 +21,13 @@ for D in ../exercises/*; do
         fi
 
         # Make it!
-        ( cd ${D};
+        { cd ${D};
           echo "Running tests for ${EXERCISE_NAME}";
           make clean >> /dev/null; # I'm just trying to suppress the output (I'm sure there's a much better way)
-          make | grep FAIL:  # Only output failures
-        )
+          if make | grep FAIL: ; then
+            set -e
+          fi
+          cd ${CURRENT_DIR};
+        }
     fi
 done

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+for D in ../exercises/*; do
+    if [ -d "${D}" ]; then
+        # Get the exercise name from the test file
+        TEST_FILE=$(basename $(ls ${D}/test/test*))
+        STRIPPED_OF_EXTENSION="${TEST_FILE%.*}"
+        EXERCISE_NAME="${STRIPPED_OF_EXTENSION:5}"
+
+        # Copy the examples with the correct name for the exercise
+        cp -f ${D}/src/example.c ${D}/src/${EXERCISE_NAME}.c
+        cp -f ${D}/src/example.h ${D}/src/${EXERCISE_NAME}.h
+
+        # Make it!
+        ( cd ${D} ; make clean; make )
+
+        # Clean up
+        rm -f ${D}/src/${EXERCISE_NAME}.c
+        rm -f ${D}/src/${EXERCISE_NAME}.h
+    fi
+done

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Remove -Wpedantic from all makefiles since it isn't supported in the GCC version used by Travis
+sed -i -- 's/-Wpedantic/-pedantic/g' exercises/*/makefile
+
 for D in exercises/*; do
     CURRENT_DIR=$(pwd)
 

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for D in ../exercises/*; do
+for D in exercises/*; do
     CURRENT_DIR=$(pwd)
 
     if [ -d "${D}" ]; then

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -23,9 +23,8 @@ for D in exercises/*; do
         # Make it!
         { cd ${D};
           echo "Running tests for ${EXERCISE_NAME}";
-          make clean >> /dev/null; # I'm just trying to suppress the output (I'm sure there's a much better way)
+          make clean >> /dev/null;
           if make | grep FAIL: ; then
-            set -e
             exit 1
           fi
           cd ${CURRENT_DIR};

--- a/exercises/anagram/makefile
+++ b/exercises/anagram/makefile
@@ -1,7 +1,7 @@
 CFLAGS  = -std=c99
 CFLAGS += -Wall
 CFLAGS += -Wextra
-CFLAGS += -Wpedantic
+CFLAGS += -pedantic
 CFLAGS += -Werror
 
 

--- a/exercises/beer-song/makefile
+++ b/exercises/beer-song/makefile
@@ -1,7 +1,7 @@
 CFLAGS  = -std=c99
 CFLAGS += -Wall
 CFLAGS += -Wextra
-CFLAGS += -Wpedantic
+CFLAGS += -pedantic
 CFLAGS += -Werror
 
 

--- a/exercises/bob/makefile
+++ b/exercises/bob/makefile
@@ -1,7 +1,7 @@
 CFLAGS  = -std=c99
 CFLAGS += -Wall
 CFLAGS += -Wextra
-CFLAGS += -Wpedantic
+CFLAGS += -pedantic
 CFLAGS += -Werror
 
 

--- a/exercises/gigasecond/makefile
+++ b/exercises/gigasecond/makefile
@@ -1,7 +1,7 @@
 CFLAGS  = -std=c99
 CFLAGS += -Wall
 CFLAGS += -Wextra
-CFLAGS += -Wpedantic
+CFLAGS += -pedantic
 CFLAGS += -Werror
 
 

--- a/exercises/grains/makefile
+++ b/exercises/grains/makefile
@@ -1,7 +1,7 @@
 CFLAGS  = -std=c99
 CFLAGS += -Wall
 CFLAGS += -Wextra
-CFLAGS += -Wpedantic
+CFLAGS += -pedantic
 CFLAGS += -Werror
 
 

--- a/exercises/hamming/makefile
+++ b/exercises/hamming/makefile
@@ -1,7 +1,7 @@
 CFLAGS  = -std=c99
 CFLAGS += -Wall
 CFLAGS += -Wextra
-CFLAGS += -Wpedantic
+CFLAGS += -pedantic
 CFLAGS += -Werror
 
 

--- a/exercises/hello-world/makefile
+++ b/exercises/hello-world/makefile
@@ -1,7 +1,7 @@
 CFLAGS  = -std=c99
 CFLAGS += -Wall
 CFLAGS += -Wextra
-CFLAGS += -Wpedantic
+CFLAGS += -pedantic
 CFLAGS += -Werror
 
 

--- a/exercises/leap/makefile
+++ b/exercises/leap/makefile
@@ -1,7 +1,7 @@
 CFLAGS  = -std=c99
 CFLAGS += -Wall
 CFLAGS += -Wextra
-CFLAGS += -Wpedantic
+CFLAGS += -pedantic
 CFLAGS += -Werror
 
 

--- a/exercises/nth-prime/makefile
+++ b/exercises/nth-prime/makefile
@@ -1,7 +1,7 @@
 CFLAGS  = -std=c99
 CFLAGS += -Wall
 CFLAGS += -Wextra
-CFLAGS += -Wpedantic
+CFLAGS += -pedantic
 CFLAGS += -Werror
 
 

--- a/exercises/pangram/makefile
+++ b/exercises/pangram/makefile
@@ -1,7 +1,7 @@
 CFLAGS  = -std=c99
 CFLAGS += -Wall
 CFLAGS += -Wextra
-CFLAGS += -Wpedantic
+CFLAGS += -pedantic
 CFLAGS += -Werror
 
 

--- a/exercises/raindrops/makefile
+++ b/exercises/raindrops/makefile
@@ -1,7 +1,7 @@
 CFLAGS  = -std=c99
 CFLAGS += -Wall
 CFLAGS += -Wextra
-CFLAGS += -Wpedantic
+CFLAGS += -pedantic
 CFLAGS += -Werror
 
 

--- a/exercises/rna-transcription/makefile
+++ b/exercises/rna-transcription/makefile
@@ -1,7 +1,7 @@
 CFLAGS = -std=c99
 CFLAGS += -Wall
 CFLAGS += -Wextra
-CFLAGS += -Wpedantic
+CFLAGS += -pedantic
 CFLAGS += -Werror
 
 test: tests.out


### PR DESCRIPTION
My idea is just to have a shell script that will copy/rename the `example.c` and `example.h` files with the appropriate names and then execute `make` in each exercise directory.  I do not claim to know anything about bash scripts, so suggestions are greatly encouraged.