### PR TITLE
Fix compiler warning in Leap

### DIFF
--- a/exercises/leap/src/example.h
+++ b/exercises/leap/src/example.h
@@ -2,6 +2,7 @@
 #define _LEAP_H
 
 #include <stdbool.h>
-bool leap_year(int year);
+
+bool is_leap_year(int year);
 
 #endif


### PR DESCRIPTION
Fixes an implicit declaration warning due to the function being implemented as `is_leap_year` and called in the tests as `is_leap_year` but being declared as `leap_year` in the sample header.

Related to #62 