### PR TITLE
Removing non-standard time functions.

### DIFF
--- a/exercises/gigasecond/src/example.c
+++ b/exercises/gigasecond/src/example.c
@@ -1,7 +1,4 @@
-#include <stdio.h>
-#include <math.h>
-
-#include "example.h"
+#include "gigasecond.h"
 
 time_t gigasecond_after(time_t start)
 {

--- a/exercises/gigasecond/src/example.h
+++ b/exercises/gigasecond/src/example.h
@@ -1,5 +1,5 @@
-#ifndef _EXAMPLE_H
-#define _EXAMPLE_H
+#ifndef _GIGASECOND_H
+#define _GIGASECOND_H
 
 #include <time.h>
 

--- a/exercises/gigasecond/test/test_gigasecond.c
+++ b/exercises/gigasecond/test/test_gigasecond.c
@@ -1,59 +1,60 @@
-#include <time.h>
-
 #include "vendor/unity.h"
 #include "../src/gigasecond.h"
 
-/* Convert a date string in the format "YYYY-MM-DD HH:MM:SS +NNNN"
- * (date, time, offset from UTC) into a time_t (seconds since Unix
- * epoch).
- */
-time_t parse_date(const char *const str)
+// Constructs a time_t type from the given date settings
+time_t construct_date(int year, int month, int day, int hour, int min, int sec)
 {
    struct tm date;
-   strptime(str, "%F %T %z", &date);
+   date.tm_year = year - 1900;
+   date.tm_mon = month - 1;
+   date.tm_mday = day;
+   date.tm_hour = hour;
+   date.tm_min = min;
+   date.tm_sec = sec;
+   date.tm_isdst = 0;
    return mktime(&date);
 }
 
 void test_date(void)
 {
-   time_t expected = parse_date("2043-01-01 01:46:40 +0000");
-   time_t actual = gigasecond_after(parse_date("2011-04-25 00:00:00 +0000"));
-   TEST_ASSERT_EQUAL_INT(expected, actual);
+   time_t expected = construct_date(2043, 1, 1, 1, 46, 40);
+   time_t actual = gigasecond_after(construct_date(2011, 4, 25, 0, 0, 0));
+   TEST_ASSERT(expected == actual);
 }
 
 void test_another_date(void)
 {
-   time_t expected = parse_date("2009-02-19 01:46:40 +0000");
-   time_t actual = gigasecond_after(parse_date("1977-06-13 00:00:00 +0000"));
-   TEST_ASSERT_EQUAL_INT(expected, actual);
+   time_t expected = construct_date(2009, 2, 19, 1, 46, 40);
+   time_t actual = gigasecond_after(construct_date(1977, 6, 13, 0, 0, 0));
+   TEST_ASSERT(expected == actual);
 }
 
 void test_third_date(void)
 {
-   time_t expected = parse_date("1991-03-27 01:46:40 +0000");
-   time_t actual = gigasecond_after(parse_date("1959-07-19 00:00:00 +0000"));
-   TEST_ASSERT_EQUAL_INT(expected, actual);
+   time_t expected = construct_date(1991, 3, 27, 1, 46, 40);
+   time_t actual = gigasecond_after(construct_date(1959, 7, 19, 0, 0, 0));
+   TEST_ASSERT(expected == actual);
 }
 
 void test_date_and_time(void)
 {
-   time_t expected = parse_date("2046-10-02 23:46:40 +0000");
-   time_t actual = gigasecond_after(parse_date("2015-01-24 22:00:00 +0000"));
-   TEST_ASSERT_EQUAL_INT(expected, actual);
+   time_t expected = construct_date(2046, 10, 2, 23, 46, 40);
+   time_t actual = gigasecond_after(construct_date(2015, 1, 24, 22, 0, 0));
+   TEST_ASSERT(expected == actual);
 }
 
 void test_date_and_time_with_day_rollover(void)
 {
-   time_t expected = parse_date("2046-10-03 01:46:39 +0000");
-   time_t actual = gigasecond_after(parse_date("2015-01-24 23:59:59 +0000"));
-   TEST_ASSERT_EQUAL_INT(expected, actual);
+   time_t expected = construct_date(2046, 10, 3, 1, 46, 39);
+   time_t actual = gigasecond_after(construct_date(2015, 1, 24, 23, 59, 59));
+   TEST_ASSERT(expected == actual);
 }
 
 /*
 void test_your_birthday(void) {
-  time_t expected = parse_date("");
-  time_t actual = gigasecond_after(parse_date(""));
-  TEST_ASSERT_EQUAL_INT(expected, actual);
+   time_t birthday = construct_date(1989,1,1,1,1,1);
+   time_t gigday = gigasecond_after(birthday);
+   printf(ctime(&gigday));
 }
 */
 

--- a/exercises/gigasecond/test/test_gigasecond.c
+++ b/exercises/gigasecond/test/test_gigasecond.c
@@ -51,8 +51,9 @@ void test_date_and_time_with_day_rollover(void)
 }
 
 /*
-void test_your_birthday(void) {
-   time_t birthday = construct_date(1989,1,1,1,1,1);
+void test_your_birthday(void)
+{
+   time_t birthday = construct_date(1989, 1, 1, 1, 1, 1);
    time_t gigday = gigasecond_after(birthday);
    printf(ctime(&gigday));
 }


### PR DESCRIPTION
Converting the gigasecond exercise to use `struct tm` and `mktime()`.

This forcibly turns off Daylight Savings Time, which may have been a contributing factor for the problems we were seeing. (If I let my system choose what to use, the tests would fail ~25% of the time. I still have no clue as to why.)

Closes #66 
Closes #60