### PR TITLE
anagram: fixing strlen error

### DIFF
--- a/exercises/anagram/src/example.c
+++ b/exercises/anagram/src/example.c
@@ -33,8 +33,8 @@ struct Vector anagrams_for(char *in, struct Vector vin)
    char (*vout_vecp)[MAX_STR_LEN] = vout.vec;
 
    char *lower = lowercase(in);
-   char *sorted = malloc(strlen(in));
-   memcpy(sorted, lower, strlen(in));
+   char *sorted = malloc(strlen(in) + 1);
+   memcpy(sorted, lower, strlen(in) + 1);
    qsort(sorted, strlen(sorted), 1, compare);
 
    char (*vecp)[MAX_STR_LEN] = vin.vec;


### PR DESCRIPTION
I believe this is the problem with the current anagram solution. For now I only spot fixed this one issue, but the rest of the problem may need to be looked at for improvements (#65 at least). If you guys think we should fix it up now I can go ahead, but this should let us get Travis up and running.

What I _think_ happened was the original `malloc` and `memcpy` threw away the null terminator. It would occasionally work if the next byte of memory was a null terminator and not otherwise. I should've just remembered to use valgrind, since that catches the overflow immediately.