### PR TITLE
Make run-test script fail if compilation has errors

### DIFF
--- a/bin/run-tests
+++ b/bin/run-tests
@@ -26,6 +26,8 @@ for D in exercises/*; do
           make clean >> /dev/null;
           if make | grep FAIL: ; then
             exit 1
+          elif [ ${PIPESTATUS[0]} -ne 0 ]; then
+            exit 1
           fi
           cd ${CURRENT_DIR};
         }

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 for D in exercises/*; do
     CURRENT_DIR=$(pwd)


### PR DESCRIPTION
Closes #91 