### PR TITLE
Remove spurious semi-colon

### DIFF
--- a/exercises/leap/test/test_leap.c
+++ b/exercises/leap/test/test_leap.c
@@ -23,7 +23,7 @@ void test_turn_of_the_21st_century(void)
 
 void test_turn_of_the_25th_century(void)
 {
-   TEST_ASSERT_TRUE(is_leap_year(2400));;
+   TEST_ASSERT_TRUE(is_leap_year(2400));
 }
 
 int main(void)


### PR DESCRIPTION
There was an extra, second, semi-colon at the end of an ASSERT line. This probably causes no harm but is nevertheless incorrect. This commit removes it.