### PR TITLE
Add format string to printf in test_your_birthday

### DIFF
--- a/exercises/gigasecond/test/test_gigasecond.c
+++ b/exercises/gigasecond/test/test_gigasecond.c
@@ -55,7 +55,7 @@ void test_your_birthday(void)
 {
    time_t birthday = construct_date(1989, 1, 1, 1, 1, 1);
    time_t gigday = gigasecond_after(birthday);
-   printf(ctime(&gigday));
+   printf("%s", ctime(&gigday));
 }
 */
 


### PR DESCRIPTION
Without this, using the code as-is, an error is given upon compilation:

~~~sh
$ make test
Compiling tests.out
test/test_gigasecond.c: In function ‘test_your_birthday’:
test/test_gigasecond.c:58:4: error: format not a string literal and no format arguments [-Werror=format-security]
    printf(ctime(&gigday));
    ^~~~~~
cc1: all warnings being treated as errors
make: *** [tests.out] Error 1
~~~