### PR TITLE
Add test for invalid indexes

### DIFF
--- a/exercises/grains/src/example.c
+++ b/exercises/grains/src/example.c
@@ -4,6 +4,10 @@
 
 uint64_t square(uint8_t index)
 {
+   if ((!index) || (index > NUMBER_OF_SQUARES)) {
+      return 0;
+   }
+
    return (uint64_t) 1 << (index - 1);
 }
 

--- a/exercises/grains/test/test_grains.c
+++ b/exercises/grains/test/test_grains.c
@@ -36,6 +36,16 @@ void test_square_64(void)
    TEST_ASSERT_EQUAL_UINT64(9223372036854775808ul, square(64));
 }
 
+void test_square_0_does_not_exist(void)
+{
+   TEST_ASSERT_EQUAL_UINT64(0, square(0));
+} 
+
+void test_square_greater_than_64_does_not_exist(void)
+{
+   TEST_ASSERT_EQUAL_UINT64(0, square(65));
+}
+
 void test_total(void)
 {
    TEST_ASSERT_EQUAL_UINT64(18446744073709551615ul, total());
@@ -52,6 +62,8 @@ int main(void)
    RUN_TEST(test_square_16);
    RUN_TEST(test_square_32);
    RUN_TEST(test_square_64);
+   RUN_TEST(test_square_0_does_not_exist);
+   RUN_TEST(test_square_greater_than_64_does_not_exist);
    RUN_TEST(test_total);
 
    UnityEnd();

--- a/exercises/grains/test/test_grains.c
+++ b/exercises/grains/test/test_grains.c
@@ -39,7 +39,7 @@ void test_square_64(void)
 void test_square_0_does_not_exist(void)
 {
    TEST_ASSERT_EQUAL_UINT64(0, square(0));
-} 
+}
 
 void test_square_greater_than_64_does_not_exist(void)
 {


### PR DESCRIPTION
A chess board does not have a zeroth square or more than 64 squares