### PR TITLE
react: Update only dependents of the just-set cell

### DIFF
--- a/exercises/react/src/example.c
+++ b/exercises/react/src/example.c
@@ -20,18 +20,20 @@ struct cb {
 };
 
 struct reactor {
-   struct child *first;
-   struct child *last;
+   struct child *input;
 };
 
 struct cell {
-   struct reactor *reactor;
    int value;
    enum cell_kind kind;
+   struct child *child;
+
    struct cell *input1;
    struct cell *input2;
    compute1 compute1;
    compute2 compute2;
+
+   int last_cb_value;
    struct cb *cb;
    int callbacks_issued;
 };
@@ -41,42 +43,54 @@ struct reactor *create_reactor()
    return calloc(1, sizeof(struct reactor));
 }
 
-void destroy_reactor(struct reactor *r)
+static void destroy_cell(struct cell *c)
 {
-   struct child *child = r->first;
-   while (child) {
-      struct cb *cb = child->cell->cb;
-      while (cb) {
-         struct cb *next_cb = cb->next;
-         free(cb);
-         cb = next_cb;
-      }
-      free(child->cell);
+   struct cb *cb = c->cb;
+   while (cb) {
+      struct cb *next_cb = cb->next;
+      free(cb);
+      cb = next_cb;
+   }
 
+   struct child *child = c->child;
+   while (child) {
       struct child *next = child->next;
+      if (c == child->cell->input1) {
+         // Don't double-free for a compute2 cell.
+         destroy_cell(child->cell);
+      }
       free(child);
       child = next;
    }
+
+   free(c);
+}
+
+void destroy_reactor(struct reactor *r)
+{
+   struct child *input = r->input;
+   while (input) {
+      struct child *next = input->next;
+      destroy_cell(input->cell);
+      free(input);
+      input = next;
+   }
+
    free(r);
 }
 
-static void add_child(struct reactor *r, struct cell *cell)
+static void add_child(struct child **list, struct cell *cell)
 {
    struct child *child = calloc(1, sizeof(struct child));
    child->cell = cell;
-   if (!r->first) {
-      r->first = child;
-   } else {
-      r->last->next = child;
-   }
-   r->last = child;
+   child->next = *list;
+   *list = child;
 }
 
 struct cell *create_input_cell(struct reactor *r, int initial_value)
 {
    struct cell *c = calloc(1, sizeof(struct cell));
-   add_child(r, c);
-   c->reactor = r;
+   add_child(&r->input, c);
    c->kind = kind_input;
    c->value = initial_value;
    return c;
@@ -85,29 +99,34 @@ struct cell *create_input_cell(struct reactor *r, int initial_value)
 struct cell *create_compute1_cell(struct reactor *r, struct cell *input,
                                   compute1 compute)
 {
+   (void)r;
    struct cell *c = calloc(1, sizeof(struct cell));
-   add_child(r, c);
-   c->reactor = r;
+   add_child(&input->child, c);
    c->kind = kind_compute1;
    c->input1 = input;
    c->compute1 = compute;
    c->value = compute(get_cell_value(input));
+   c->last_cb_value = c->value;
    return c;
 }
 
 struct cell *create_compute2_cell(struct reactor *r, struct cell *input1,
                                   struct cell *input2, compute2 compute)
 {
+   (void)r;
    struct cell *c = calloc(1, sizeof(struct cell));
-   add_child(r, c);
-   c->reactor = r;
+   add_child(&input1->child, c);
+   add_child(&input2->child, c);
    c->kind = kind_compute2;
    c->input1 = input1;
    c->input2 = input2;
    c->compute2 = compute;
    c->value = compute(get_cell_value(input1), get_cell_value(input2));
+   c->last_cb_value = c->value;
    return c;
 }
+
+#define each_child(c) struct child *child = (c)->child; child; child = child->next
 
 int get_cell_value(struct cell *c)
 {
@@ -131,23 +150,37 @@ static void propagate(struct cell *c)
 
    if (new_value != c->value) {
       c->value = new_value;
-      for (struct cb * cb = c->cb; cb; cb = cb->next) {
-         cb->f(cb->obj, new_value);
+      for (each_child(c)) {
+         propagate(child->cell);
       }
    }
+}
 
+static void fire_callbacks(struct cell *c)
+{
+   if (c->value == c->last_cb_value) {
+      return;
+   }
+   c->last_cb_value = c->value;
+   for (struct cb * cb = c->cb; cb; cb = cb->next) {
+      cb->f(cb->obj, c->value);
+   }
+   for (each_child(c)) {
+      fire_callbacks(child->cell);
+   }
 }
 
 void set_cell_value(struct cell *c, int new_value)
 {
    c->value = new_value;
-   struct reactor *r = c->reactor;
-
-   // We take the very naive route of updating all cells.
-   // Traversing the tree and only updating the cells dependent on the just-changed cell is possible,
-   // but requires much more memory management to make each cell aware of its dependents.
-   for (struct child * child = r->first; child; child = child->next) {
+   for (each_child(c)) {
       propagate(child->cell);
+   }
+   for (each_child(c)) {
+      // Why can't we put propagate and fire_callbacks in same for loop?
+      // Because then a compute2 cell might fire its callbacks too early
+      // (before it's seen updates from both of its inputs)!
+      fire_callbacks(child->cell);
    }
 }
 


### PR DESCRIPTION
The initial version of react (see #126) let the reactor store all cells
in a linked list, then blindly updated all cells whenever any cell was
set. This was correct but wasteful.

This commit rearchitects the example solution so that:

* reactors only keep track of the input cells
* all other cells keep track of their dependent compute cells
* only dependents get updated when a cell is set

Space cost of:

* one extra `struct child` allocated per compute2 cell created.
* one extra integer field per cell.