### PR TITLE
perfect_number: Optimize example solution

### DIFF
--- a/exercises/perfect-numbers/src/example.c
+++ b/exercises/perfect-numbers/src/example.c
@@ -2,13 +2,17 @@
 
 static int aliquot_sum(int n)
 {
-   int result = 0;
-   for (int i = 1; i < n; ++i) {
+   if (n == 1) {
+      return 0;
+   }
+   int result = 1;
+   int i;
+   for (i = 2; i * i < n; ++i) {
       if ((n % i) == 0) {
-         result = result + i;
+         result += i + (n / i);
       }
    }
-   return result;
+   return result + (i * i == n ? i : 0);
 }
 
 kind classify_number(int n)


### PR DESCRIPTION
When running all the tests using bin/run-tests there is a notable pause while running perfect_numbers, so I made a small optimization to speed up the example solution.

This is totally unnecessary, but the new version is a better example solution for anyone that ends up looking at it.