### PR TITLE
Delete ignored key from config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -327,11 +327,6 @@
   "deprecated": [
 
   ],
-  "ignored": [
-    "vendor",
-    "docs",
-    "img"
-  ],
   "foregone": [
 
   ]


### PR DESCRIPTION
Since the exercise implementations are all in the exercises directory
we no longer need to ignore any non-exercise directories in the root
of the track.

See https://github.com/exercism/meta/issues/3 for context.